### PR TITLE
Provide schema type to drizzle orm constructor

### DIFF
--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,9 +1,10 @@
 import "dotenv/config";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { Database } from "bun:sqlite";
+import * as schema from "./schema";
 
 console.log(process.env.DB_FILE_NAME!);
 
 const sqlite = new Database(process.env.DB_FILE_NAME!);
 
-export const db = drizzle(sqlite);
+export const db = drizzle<typeof schema>(sqlite);


### PR DESCRIPTION
Drizzle instance now properly typed, can access schema tables from which to query.